### PR TITLE
Fixed NPM Resolve Issues

### DIFF
--- a/src/compiler/utilities/tooling/index.ts
+++ b/src/compiler/utilities/tooling/index.ts
@@ -85,7 +85,7 @@ export class Tooling {
 
     public static resolve(path:string, resolveDir:string=""):string|null {
         let local = Files.join(resolveDir, path);
-        let npm   = Files.join("../../../node_modules", path);
+        let npm   = Files.join(resolveDir, "../../../node_modules", path);
         if (Files.exists(local)) {
             return local;
         }


### PR DESCRIPTION
The system was unable to resolve the NPM package when loading modules. The issue was because the node modules directory was not checked relative to the resolve directory.